### PR TITLE
feat: add getAllChunks to libsql-db

### DIFF
--- a/core/embedjs-interfaces/src/interfaces/base-vector-database.ts
+++ b/core/embedjs-interfaces/src/interfaces/base-vector-database.ts
@@ -8,4 +8,6 @@ export interface BaseVectorDatabase {
 
     deleteKeys(uniqueLoaderId: string): Promise<boolean>;
     reset(): Promise<void>;
+
+    getAllChunks?(): Promise<Array<{ pageContent: string; metadata: Record<string, unknown> }> | undefined>;
 }

--- a/databases/embedjs-libsql/src/libsql-db.ts
+++ b/databases/embedjs-libsql/src/libsql-db.ts
@@ -86,4 +86,15 @@ export class LibSqlDb implements BaseVectorDatabase {
     async reset(): Promise<void> {
         await this.client.execute(`DELETE FROM ${this.tableName};`);
     }
+
+    async getAllChunks(): Promise<Array<{ pageContent: string; metadata: Record<string, unknown> }>> {
+        const statement = `SELECT pageContent, metadata FROM ${this.tableName}`;
+        this.debug(`Executing statement - ${statement}`);
+        const results = await this.client.execute(statement);
+
+        return results.rows.map((row) => ({
+            pageContent: row.pageContent.toString(),
+            metadata: JSON.parse(row.metadata.toString()),
+        }));
+    }
 }


### PR DESCRIPTION
## Description

增加一个 `getAllChunks` 来获取所有 chunks，用于知识库迁移。
这个是否可行？允许知识库更换模型、嵌入维度，在更换后执行迁移 @eeee0717 

Fixes # (issue)

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new tsc or eslint warnings
-   [ ] I have ran tests that prove my fix is effective or that my feature works
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] My changes do not result in new npm audit errors
