### PR TITLE
fix(ollama): support current and legacy embedding responses

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,5 @@ jobs:
               run: npm ci
             - name: Test build
               run: npm run build:ci
+            - name: Run Ollama tests
+              run: npx nx run embedjs-ollama:test

--- a/core/embedjs-interfaces/src/index.ts
+++ b/core/embedjs-interfaces/src/index.ts
@@ -1,9 +1,7 @@
-import { BaseLoader } from './interfaces/base-loader.js';
-import { BaseVectorDatabase } from './interfaces/base-vector-database.js';
-import { BaseEmbeddings } from './interfaces/base-embeddings.js';
-import { BaseStore } from './interfaces/base-store.js';
-import { BaseModel } from './interfaces/base-model.js';
-
 export * from './types.js';
 export * from './constants.js';
-export { BaseStore, BaseVectorDatabase, BaseLoader, BaseEmbeddings, BaseModel };
+export { BaseLoader } from './interfaces/base-loader.js';
+export { BaseEmbeddings } from './interfaces/base-embeddings.js';
+export { BaseModel } from './interfaces/base-model.js';
+export type { BaseStore } from './interfaces/base-store.js';
+export type { BaseVectorDatabase } from './interfaces/base-vector-database.js';

--- a/core/embedjs-interfaces/src/interfaces/base-loader.ts
+++ b/core/embedjs-interfaces/src/interfaces/base-loader.ts
@@ -2,9 +2,9 @@ import md5 from 'md5';
 import createDebugMessages from 'debug';
 import { EventEmitter } from 'node:events';
 
-import { BaseStore } from './base-store.js';
-import { LoaderChunk, UnfilteredLoaderChunk } from '../types.js';
-import { BaseModel } from './base-model.js';
+import type { BaseStore } from './base-store.js';
+import type { LoaderChunk, UnfilteredLoaderChunk } from '../types.js';
+import type { BaseModel } from './base-model.js';
 
 export abstract class BaseLoader<
     MetadataTemplate extends Record<string, string | number | boolean | string[]> = Record<string, string | number | boolean| string[]>,

--- a/core/embedjs-interfaces/src/interfaces/base-model.ts
+++ b/core/embedjs-interfaces/src/interfaces/base-model.ts
@@ -2,8 +2,8 @@ import { HumanMessage, AIMessage, SystemMessage } from '@langchain/core/messages
 import createDebugMessages from 'debug';
 import { v4 as uuidv4 } from 'uuid';
 
-import { Chunk, QueryResponse, Message, SourceDetail, ModelResponse, Conversation } from '../types.js';
-import { BaseStore } from './base-store.js';
+import type { Chunk, QueryResponse, Message, SourceDetail, ModelResponse, Conversation } from '../types.js';
+import type { BaseStore } from './base-store.js';
 
 export abstract class BaseModel {
     private readonly baseDebug = createDebugMessages('embedjs:model:BaseModel');

--- a/core/embedjs-interfaces/src/interfaces/base-store.ts
+++ b/core/embedjs-interfaces/src/interfaces/base-store.ts
@@ -1,4 +1,4 @@
-import { Conversation, LoaderListEntry, Message } from '../types.js';
+import type { Conversation, LoaderListEntry, Message } from '../types.js';
 
 export interface BaseStore {
     init(): Promise<void>;

--- a/core/embedjs-interfaces/src/interfaces/base-vector-database.ts
+++ b/core/embedjs-interfaces/src/interfaces/base-vector-database.ts
@@ -1,4 +1,4 @@
-import { ExtractChunkData, InsertChunkData } from '../types.js';
+import type { ExtractChunkData, InsertChunkData } from '../types.js';
 
 export interface BaseVectorDatabase {
     init({ dimensions }: { dimensions: number }): Promise<void>;

--- a/models/embedjs-ollama/package.json
+++ b/models/embedjs-ollama/package.json
@@ -36,5 +36,8 @@
     "repository": {
         "type": "git",
         "url": "git+https://github.com/CherryHQ/embed-js.git"
+    },
+    "devDependencies": {
+        "tsx": "^4.21.0"
     }
 }

--- a/models/embedjs-ollama/project.json
+++ b/models/embedjs-ollama/project.json
@@ -24,6 +24,13 @@
                 "main": "models/embedjs-ollama/src/index.ts",
                 "tsConfig": "models/embedjs-ollama/tsconfig.cjs.json"
             }
+        },
+        "test": {
+            "executor": "nx:run-commands",
+            "options": {
+                "cwd": "models/embedjs-ollama",
+                "command": "npx tsx --test src/ollama-embeddings.test.ts"
+            }
         }
     }
 }

--- a/models/embedjs-ollama/src/ollama-embeddings.test.ts
+++ b/models/embedjs-ollama/src/ollama-embeddings.test.ts
@@ -51,7 +51,7 @@ function stubFetch(responses: Response[]) {
     };
 }
 
-test('returns configured dimensions without probing Ollama', async (t) => {
+test('returns configured dimensions without probing Ollama', async () => {
     const originalFetch = globalThis.fetch;
     let fetchCalls = 0;
 
@@ -60,85 +60,148 @@ test('returns configured dimensions without probing Ollama', async (t) => {
         throw new Error('Fetch should not be called when dimensions are configured');
     }) as typeof fetch;
 
-    t.after(() => {
+    try {
+        const embeddings = new OllamaEmbeddings({
+            model: 'nomic-embed-text',
+            baseUrl: 'http://localhost:11434',
+            dimensions: 768,
+        });
+
+        await assert.doesNotReject(async () => {
+            assert.equal(await embeddings.getDimensions(), 768);
+        });
+        assert.equal(fetchCalls, 0);
+    } finally {
         globalThis.fetch = originalFetch;
-    });
-
-    const embeddings = new OllamaEmbeddings({
-        model: 'nomic-embed-text',
-        baseUrl: 'http://localhost:11434',
-        dimensions: 768,
-    });
-
-    await assert.doesNotReject(async () => {
-        assert.equal(await embeddings.getDimensions(), 768);
-    });
-    assert.equal(fetchCalls, 0);
+    }
 });
 
-test('uses the current /api/embed response shape for dimension probing', async (t) => {
+test('uses the current /api/embed response shape for dimension probing', async () => {
     const fetchStub = stubFetch([
         createJsonResponse({
             embeddings: [[0.1, 0.2, 0.3, 0.4]],
         }),
     ]);
 
-    t.after(() => {
+    try {
+        const embeddings = new OllamaEmbeddings({
+            model: 'nomic-embed-text',
+            baseUrl: 'http://localhost:11434',
+        });
+
+        assert.equal(await embeddings.getDimensions(), 4);
+        assert.equal(fetchStub.calls.length, 1);
+        assert.equal(fetchStub.calls[0].url, 'http://localhost:11434/api/embed');
+        assert.equal(fetchStub.calls[0].init?.method, 'POST');
+        assert.deepEqual(JSON.parse(fetchStub.calls[0].init?.body as string), {
+            model: 'nomic-embed-text',
+            input: 'sample',
+        });
+    } finally {
         fetchStub.restore();
-    });
-
-    const embeddings = new OllamaEmbeddings({
-        model: 'nomic-embed-text',
-        baseUrl: 'http://localhost:11434',
-    });
-
-    assert.equal(await embeddings.getDimensions(), 4);
-    assert.equal(fetchStub.calls.length, 1);
-    assert.equal(fetchStub.calls[0].url, 'http://localhost:11434/api/embed');
-    assert.equal(fetchStub.calls[0].init?.method, 'POST');
-    assert.deepEqual(JSON.parse(fetchStub.calls[0].init?.body as string), {
-        model: 'nomic-embed-text',
-        input: 'sample',
-        truncate: false,
-    });
+    }
 });
 
-test('falls back to legacy /api/embeddings when /api/embed fails', async (t) => {
+test('preserves an explicitly configured truncate flag', async () => {
+    const fetchStub = stubFetch([
+        createJsonResponse({
+            embeddings: [[0.1, 0.2, 0.3, 0.4]],
+        }),
+    ]);
+
+    try {
+        const embeddings = new OllamaEmbeddings({
+            model: 'nomic-embed-text',
+            baseUrl: 'http://localhost:11434',
+            truncate: true,
+        });
+
+        assert.equal(await embeddings.getDimensions(), 4);
+        assert.equal(fetchStub.calls.length, 1);
+        assert.deepEqual(JSON.parse(fetchStub.calls[0].init?.body as string), {
+            model: 'nomic-embed-text',
+            input: 'sample',
+            truncate: true,
+        });
+    } finally {
+        fetchStub.restore();
+    }
+});
+
+test('falls back to legacy /api/embeddings when /api/embed fails', async () => {
     const fetchStub = stubFetch([
         createJsonResponse({ error: 'not found' }, { status: 404 }),
         createJsonResponse({ embedding: [1, 2, 3] }),
         createJsonResponse({ embedding: [4, 5, 6] }),
     ]);
 
-    t.after(() => {
+    try {
+        const embeddings = new OllamaEmbeddings({
+            model: 'nomic-embed-text',
+            baseUrl: 'http://localhost:11434',
+        });
+
+        assert.deepEqual(await embeddings.embedDocuments(['first', 'second']), [
+            [1, 2, 3],
+            [4, 5, 6],
+        ]);
+
+        assert.equal(fetchStub.calls.length, 3);
+        assert.equal(fetchStub.calls[0].url, 'http://localhost:11434/api/embed');
+        assert.deepEqual(JSON.parse(fetchStub.calls[0].init?.body as string), {
+            model: 'nomic-embed-text',
+            input: ['first', 'second'],
+        });
+        assert.equal(fetchStub.calls[1].url, 'http://localhost:11434/api/embeddings');
+        assert.deepEqual(JSON.parse(fetchStub.calls[1].init?.body as string), {
+            model: 'nomic-embed-text',
+            prompt: 'first',
+        });
+        assert.equal(fetchStub.calls[2].url, 'http://localhost:11434/api/embeddings');
+        assert.deepEqual(JSON.parse(fetchStub.calls[2].init?.body as string), {
+            model: 'nomic-embed-text',
+            prompt: 'second',
+        });
+    } finally {
         fetchStub.restore();
-    });
+    }
+});
 
-    const embeddings = new OllamaEmbeddings({
-        model: 'nomic-embed-text',
-        baseUrl: 'http://localhost:11434',
-    });
+test('does not fall back to legacy /api/embeddings for non-compatibility failures', async () => {
+    const fetchStub = stubFetch([new Response('upstream failure', { status: 500 })]);
 
-    assert.deepEqual(await embeddings.embedDocuments(['first', 'second']), [
-        [1, 2, 3],
-        [4, 5, 6],
-    ]);
+    try {
+        const embeddings = new OllamaEmbeddings({
+            model: 'nomic-embed-text',
+            baseUrl: 'http://localhost:11434',
+        });
 
-    assert.equal(fetchStub.calls.length, 3);
-    assert.equal(fetchStub.calls[0].url, 'http://localhost:11434/api/embed');
-    assert.deepEqual(JSON.parse(fetchStub.calls[0].init?.body as string), {
-        model: 'nomic-embed-text',
-        input: ['first', 'second'],
-        truncate: false,
-    });
-    assert.equal(fetchStub.calls[1].url, 'http://localhost:11434/api/embeddings');
-    assert.deepEqual(JSON.parse(fetchStub.calls[1].init?.body as string), {
-        model: 'nomic-embed-text',
-        prompt: 'first',
-    });
-    assert.equal(fetchStub.calls[2].url, 'http://localhost:11434/api/embeddings');
-    assert.deepEqual(JSON.parse(fetchStub.calls[2].init?.body as string), {
-        model: 'nomic-embed-text',
-        prompt: 'second',
-    });
+        await assert.rejects(async () => embeddings.embedDocuments(['first']), /upstream failure/);
+        assert.equal(fetchStub.calls.length, 1);
+        assert.equal(fetchStub.calls[0].url, 'http://localhost:11434/api/embed');
+    } finally {
+        fetchStub.restore();
+    }
+});
+
+test('does not fall back to legacy /api/embeddings when dimensions are configured', async () => {
+    const fetchStub = stubFetch([new Response('missing current api', { status: 404 })]);
+
+    try {
+        const embeddings = new OllamaEmbeddings({
+            model: 'nomic-embed-text',
+            baseUrl: 'http://localhost:11434',
+            dimensions: 768,
+        });
+
+        await assert.rejects(async () => embeddings.embedDocuments(['first']), /missing current api/);
+        assert.equal(fetchStub.calls.length, 1);
+        assert.deepEqual(JSON.parse(fetchStub.calls[0].init?.body as string), {
+            model: 'nomic-embed-text',
+            input: 'first',
+            dimensions: 768,
+        });
+    } finally {
+        fetchStub.restore();
+    }
 });

--- a/models/embedjs-ollama/src/ollama-embeddings.test.ts
+++ b/models/embedjs-ollama/src/ollama-embeddings.test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { OllamaEmbeddings } from './ollama-embeddings.js';
+
+function createJsonResponse(payload: unknown, init?: ResponseInit): Response {
+    return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        ...init,
+    });
+}
+
+function getRequestUrl(input: Parameters<typeof fetch>[0]): string {
+    if (typeof input === 'string') {
+        return input;
+    }
+
+    if (input instanceof URL) {
+        return input.toString();
+    }
+
+    return input.url;
+}
+
+function stubFetch(responses: Response[]) {
+    const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = (async (input, init) => {
+        calls.push({
+            url: getRequestUrl(input),
+            init,
+        });
+
+        const response = responses.shift();
+        if (!response) {
+            throw new Error('Unexpected fetch call');
+        }
+
+        return response;
+    }) as typeof fetch;
+
+    return {
+        calls,
+        restore() {
+            globalThis.fetch = originalFetch;
+        },
+    };
+}
+
+test('returns configured dimensions without probing Ollama', async (t) => {
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+
+    globalThis.fetch = (async () => {
+        fetchCalls += 1;
+        throw new Error('Fetch should not be called when dimensions are configured');
+    }) as typeof fetch;
+
+    t.after(() => {
+        globalThis.fetch = originalFetch;
+    });
+
+    const embeddings = new OllamaEmbeddings({
+        model: 'nomic-embed-text',
+        baseUrl: 'http://localhost:11434',
+        dimensions: 768,
+    });
+
+    await assert.doesNotReject(async () => {
+        assert.equal(await embeddings.getDimensions(), 768);
+    });
+    assert.equal(fetchCalls, 0);
+});
+
+test('uses the current /api/embed response shape for dimension probing', async (t) => {
+    const fetchStub = stubFetch([
+        createJsonResponse({
+            embeddings: [[0.1, 0.2, 0.3, 0.4]],
+        }),
+    ]);
+
+    t.after(() => {
+        fetchStub.restore();
+    });
+
+    const embeddings = new OllamaEmbeddings({
+        model: 'nomic-embed-text',
+        baseUrl: 'http://localhost:11434',
+    });
+
+    assert.equal(await embeddings.getDimensions(), 4);
+    assert.equal(fetchStub.calls.length, 1);
+    assert.equal(fetchStub.calls[0].url, 'http://localhost:11434/api/embed');
+    assert.equal(fetchStub.calls[0].init?.method, 'POST');
+    assert.deepEqual(JSON.parse(fetchStub.calls[0].init?.body as string), {
+        model: 'nomic-embed-text',
+        input: 'sample',
+        truncate: false,
+    });
+});
+
+test('falls back to legacy /api/embeddings when /api/embed fails', async (t) => {
+    const fetchStub = stubFetch([
+        createJsonResponse({ error: 'not found' }, { status: 404 }),
+        createJsonResponse({ embedding: [1, 2, 3] }),
+        createJsonResponse({ embedding: [4, 5, 6] }),
+    ]);
+
+    t.after(() => {
+        fetchStub.restore();
+    });
+
+    const embeddings = new OllamaEmbeddings({
+        model: 'nomic-embed-text',
+        baseUrl: 'http://localhost:11434',
+    });
+
+    assert.deepEqual(await embeddings.embedDocuments(['first', 'second']), [
+        [1, 2, 3],
+        [4, 5, 6],
+    ]);
+
+    assert.equal(fetchStub.calls.length, 3);
+    assert.equal(fetchStub.calls[0].url, 'http://localhost:11434/api/embed');
+    assert.deepEqual(JSON.parse(fetchStub.calls[0].init?.body as string), {
+        model: 'nomic-embed-text',
+        input: ['first', 'second'],
+        truncate: false,
+    });
+    assert.equal(fetchStub.calls[1].url, 'http://localhost:11434/api/embeddings');
+    assert.deepEqual(JSON.parse(fetchStub.calls[1].init?.body as string), {
+        model: 'nomic-embed-text',
+        prompt: 'first',
+    });
+    assert.equal(fetchStub.calls[2].url, 'http://localhost:11434/api/embeddings');
+    assert.deepEqual(JSON.parse(fetchStub.calls[2].init?.body as string), {
+        model: 'nomic-embed-text',
+        prompt: 'second',
+    });
+});

--- a/models/embedjs-ollama/src/ollama-embeddings.ts
+++ b/models/embedjs-ollama/src/ollama-embeddings.ts
@@ -1,36 +1,154 @@
-import { OllamaEmbeddings as OllamaEmbedding, OllamaInput } from '@langchain/ollama';
 import { BaseEmbeddings } from '@cherrystudio/embedjs-interfaces';
 
-export class OllamaEmbeddings extends BaseEmbeddings {
-    private model: OllamaEmbedding;
+type OllamaEmbeddingsOptions = {
+    model: string;
+    baseUrl: string;
+    dimensions?: number;
+    keepAlive?: string | number;
+    truncate?: boolean;
+    requestOptions?: Record<string, unknown>;
+    headers?: Record<string, string>;
+};
 
-    constructor(options: {
-        model: string;
-        baseUrl: string;
-        /** Defaults to "5m" */
-        keepAlive?: string;
-        requestOptions?: Omit<OllamaInput, 'baseUrl' | 'model' | 'format' | 'headers'>;
-    }) {
+type OllamaEmbeddingsResponse = {
+    embeddings?: unknown;
+    embedding?: unknown;
+};
+
+export class OllamaEmbeddings extends BaseEmbeddings {
+    private readonly model: string;
+    private readonly baseUrl: string;
+    private readonly dimensions?: number;
+    private resolvedDimensions?: number;
+    private readonly keepAlive?: string | number;
+    private readonly truncate: boolean;
+    private readonly requestOptions?: Record<string, unknown>;
+    private readonly headers?: Record<string, string>;
+
+    constructor(options: OllamaEmbeddingsOptions) {
         super();
 
-        this.model = new OllamaEmbedding({
-            model: options.model,
-            baseUrl: options.baseUrl,
-            keepAlive: options?.keepAlive,
-            requestOptions: options?.requestOptions,
-        });
+        this.model = options.model;
+        this.baseUrl = options.baseUrl;
+        this.dimensions = options.dimensions;
+        this.keepAlive = options.keepAlive;
+        this.truncate = options.truncate ?? false;
+        this.requestOptions = options.requestOptions;
+        this.headers = options.headers;
     }
 
     override async getDimensions(): Promise<number> {
-        const sample = await this.model.embedDocuments(['sample']);
-        return sample[0].length;
+        if (this.dimensions !== undefined) {
+            return this.dimensions;
+        }
+
+        if (this.resolvedDimensions !== undefined) {
+            return this.resolvedDimensions;
+        }
+
+        const sampleEmbedding = await this.embedQuery('sample');
+        if (!(sampleEmbedding?.length)) {
+            throw new Error('Ollama embedding response did not include an embedding vector');
+        }
+
+        this.resolvedDimensions = sampleEmbedding.length;
+        return this.resolvedDimensions;
     }
 
     override async embedDocuments(texts: string[]): Promise<number[][]> {
-        return this.model.embedDocuments(texts);
+        return this.embed(texts);
     }
 
     override async embedQuery(text: string): Promise<number[]> {
-        return this.model.embedQuery(text);
+        const embeddings = await this.embed([text]);
+        const embedding = embeddings[0];
+
+        if (!(embedding?.length)) {
+            throw new Error('Ollama embedding response did not include an embedding vector');
+        }
+
+        return embedding;
+    }
+
+    private async embed(texts: string[]): Promise<number[][]> {
+        try {
+            const response = await this.post('/api/embed', {
+                model: this.model,
+                input: texts.length === 1 ? texts[0] : texts,
+                keep_alive: this.keepAlive,
+                truncate: this.truncate,
+                dimensions: this.dimensions,
+                options: this.requestOptions,
+            });
+
+            return this.normalizeEmbeddings(response);
+        } catch (currentApiError) {
+            try {
+                return await Promise.all(texts.map((text) => this.embedWithLegacyApi(text)));
+            } catch (legacyApiError) {
+                throw new Error('Ollama embeddings request failed using both /api/embed and legacy /api/embeddings', {
+                    cause: legacyApiError instanceof Error ? legacyApiError : currentApiError,
+                });
+            }
+        }
+    }
+
+    private async embedWithLegacyApi(text: string): Promise<number[]> {
+        const response = await this.post('/api/embeddings', {
+            model: this.model,
+            prompt: text,
+            keep_alive: this.keepAlive,
+            options: this.requestOptions,
+        });
+        const embeddings = this.normalizeEmbeddings(response);
+        const embedding = embeddings[0];
+
+        if (!(embedding?.length)) {
+            throw new Error('Ollama legacy embeddings response did not include an embedding vector');
+        }
+
+        return embedding;
+    }
+
+    private async post(path: string, body: Record<string, unknown>): Promise<OllamaEmbeddingsResponse> {
+        const headers = new Headers(this.headers);
+        if (!headers.has('Content-Type')) {
+            headers.set('Content-Type', 'application/json');
+        }
+
+        const response = await fetch(new URL(path, this.baseUrl).toString(), {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(body),
+        });
+
+        if (!response.ok) {
+            const message = await response.text();
+            throw new Error(message || `Ollama request failed with status ${response.status}`);
+        }
+
+        return (await response.json()) as OllamaEmbeddingsResponse;
+    }
+
+    private normalizeEmbeddings(response: OllamaEmbeddingsResponse): number[][] {
+        const currentEmbeddings = response.embeddings;
+        if (this.isEmbeddingMatrix(currentEmbeddings) && currentEmbeddings.length > 0) {
+            return currentEmbeddings;
+        }
+
+        const legacyEmbedding = response.embedding;
+        if (this.isEmbeddingVector(legacyEmbedding) && legacyEmbedding.length > 0) {
+            return [legacyEmbedding];
+        }
+
+        throw new Error('Ollama embedding response did not include embeddings');
+    }
+
+    private isEmbeddingMatrix(value: unknown): value is number[][] {
+        return Array.isArray(value) && value.every((item) => this.isEmbeddingVector(item));
+    }
+
+    private isEmbeddingVector(value: unknown): value is number[] {
+        return Array.isArray(value) && value.every((item) => typeof item === 'number');
     }
 }

--- a/models/embedjs-ollama/src/ollama-embeddings.ts
+++ b/models/embedjs-ollama/src/ollama-embeddings.ts
@@ -1,5 +1,9 @@
 import { BaseEmbeddings } from '@cherrystudio/embedjs-interfaces';
 
+type OllamaRequestError = Error & {
+    status?: number;
+};
+
 type OllamaEmbeddingsOptions = {
     model: string;
     baseUrl: string;
@@ -21,7 +25,7 @@ export class OllamaEmbeddings extends BaseEmbeddings {
     private readonly dimensions?: number;
     private resolvedDimensions?: number;
     private readonly keepAlive?: string | number;
-    private readonly truncate: boolean;
+    private readonly truncate?: boolean;
     private readonly requestOptions?: Record<string, unknown>;
     private readonly headers?: Record<string, string>;
 
@@ -32,7 +36,7 @@ export class OllamaEmbeddings extends BaseEmbeddings {
         this.baseUrl = options.baseUrl;
         this.dimensions = options.dimensions;
         this.keepAlive = options.keepAlive;
-        this.truncate = options.truncate ?? false;
+        this.truncate = options.truncate;
         this.requestOptions = options.requestOptions;
         this.headers = options.headers;
     }
@@ -83,6 +87,10 @@ export class OllamaEmbeddings extends BaseEmbeddings {
 
             return this.normalizeEmbeddings(response);
         } catch (currentApiError) {
+            if (!this.shouldFallbackToLegacyApi(currentApiError)) {
+                throw currentApiError;
+            }
+
             try {
                 return await Promise.all(texts.map((text) => this.embedWithLegacyApi(text)));
             } catch (legacyApiError) {
@@ -124,7 +132,9 @@ export class OllamaEmbeddings extends BaseEmbeddings {
 
         if (!response.ok) {
             const message = await response.text();
-            throw new Error(message || `Ollama request failed with status ${response.status}`);
+            const error = new Error(message || `Ollama request failed with status ${response.status}`) as OllamaRequestError;
+            error.status = response.status;
+            throw error;
         }
 
         return (await response.json()) as OllamaEmbeddingsResponse;
@@ -150,5 +160,18 @@ export class OllamaEmbeddings extends BaseEmbeddings {
 
     private isEmbeddingVector(value: unknown): value is number[] {
         return Array.isArray(value) && value.every((item) => typeof item === 'number');
+    }
+
+    private shouldFallbackToLegacyApi(error: unknown): boolean {
+        if (this.dimensions !== undefined || this.truncate !== undefined) {
+            return false;
+        }
+
+        if (!(error instanceof Error)) {
+            return false;
+        }
+
+        const status = (error as OllamaRequestError).status;
+        return status === 404 || status === 405;
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1743,6 +1743,9 @@
                 "@langchain/core": "^0.3.26",
                 "@langchain/ollama": "^0.1.4",
                 "debug": "^4.4.0"
+            },
+            "devDependencies": {
+                "tsx": "^4.21.0"
             }
         },
         "models/embedjs-openai": {
@@ -1858,6 +1861,7 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
             "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
@@ -2200,6 +2204,7 @@
             "version": "3.775.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.775.0.tgz",
             "integrity": "sha512-D8Zre5W2sXC/ANPqCWPqwYpU1cKY9DF6ckFZyDrqlcBC0gANgpY6fLrBtYo2fwJsbj+1A24iIpBINV7erdprgA==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.775.0",
                 "@aws-sdk/credential-provider-http": "3.775.0",
@@ -2272,6 +2277,7 @@
             "version": "3.775.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.775.0.tgz",
             "integrity": "sha512-THvyeStdvd0z8Dv1lJ7KrMRiZkFfUktYQUvvFT45ph14jHC5oRoPColtLHz4JjuDN5QEQ5EGrbc6USADZu1k/w==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/client-cognito-identity": "3.775.0",
                 "@aws-sdk/core": "3.775.0",
@@ -2878,6 +2884,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
             "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.26.2",
@@ -5138,6 +5145,23 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@esbuild/netbsd-x64": {
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
@@ -5154,6 +5178,23 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@esbuild/openbsd-x64": {
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
@@ -5168,6 +5209,23 @@
             ],
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/sunos-x64": {
@@ -5373,6 +5431,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/@huggingface/inference/-/inference-2.8.1.tgz",
             "integrity": "sha512-EfsNtY9OR6JCNaUa5bZu2mrs48iqeTz0Gutwf+fU0Kypx33xFQB4DKMhp8u4Ee6qVbLbNWvTHuWwlppLQl4p4Q==",
+            "peer": true,
             "dependencies": {
                 "@huggingface/tasks": "^0.12.9"
             },
@@ -6462,6 +6521,7 @@
             "version": "0.3.15",
             "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-0.3.15.tgz",
             "integrity": "sha512-Ar2viYcZ64idgV7EtCBCb36tIkNtPAhQRxSaMTWPHGspFgMfvwRoleVri9e90sCpjpS9xhlHsIQ0LlUS/Atsrw==",
+            "peer": true,
             "dependencies": {
                 "@anthropic-ai/sdk": "^0.37.0",
                 "fast-xml-parser": "^4.4.1",
@@ -6506,6 +6566,7 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/@langchain/cohere/-/cohere-0.3.2.tgz",
             "integrity": "sha512-AWUH6DPUnn7jmuFvNMtS0VDL+fW06edQmXFxGvWvIlXFSezqECnV4opni8zCAlWgh5NGSROLtqAZc879dt5TGg==",
+            "peer": true,
             "dependencies": {
                 "cohere-ai": "^7.14.0",
                 "uuid": "^10.0.0",
@@ -6523,6 +6584,7 @@
             "version": "0.3.43",
             "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.43.tgz",
             "integrity": "sha512-DwiSUwmZqcuOn7j8SFdeOH1nvaUqG7q8qn3LhobdQYEg5PmjLgd2yLr2KzuT/YWMBfjkOR+Di5K6HEdFmouTxg==",
+            "peer": true,
             "dependencies": {
                 "@cfworker/json-schema": "^4.0.2",
                 "ansi-styles": "^5.0.0",
@@ -6586,6 +6648,7 @@
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/@langchain/google-vertexai/-/google-vertexai-0.1.8.tgz",
             "integrity": "sha512-n06ohihopz38agOm7BTASHMmFLz+XAZlzEvqtPC4Qa1fhYhzETQg2gCzEapIJ1yVk5MhrWqwKnVOQ+tIsFE88Q==",
+            "peer": true,
             "dependencies": {
                 "@langchain/google-gauth": "~0.1.8"
             },
@@ -6600,6 +6663,7 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/@langchain/mistralai/-/mistralai-0.2.0.tgz",
             "integrity": "sha512-VdfbKZopAuSXf/vlXbriGWLK3c7j5s47DoB3S31xpprY2BMSKZZiX9vE9TsgxMfAPuIDPIYcfgU7p1upvTYt8g==",
+            "peer": true,
             "dependencies": {
                 "@mistralai/mistralai": "^1.3.1",
                 "uuid": "^10.0.0",
@@ -6617,6 +6681,7 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/@langchain/ollama/-/ollama-0.1.6.tgz",
             "integrity": "sha512-hS+xHiRqKpq37eGyZQ0JoTghfNA7hWXK54XbILQ0KVm3v2MMWLKqBAep4LwMLrAr4NE7SIp+SJnQRdsjabR0jw==",
+            "peer": true,
             "dependencies": {
                 "ollama": "^0.5.12",
                 "uuid": "^10.0.0",
@@ -7912,6 +7977,7 @@
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.4.tgz",
             "integrity": "sha512-lAS9k7d6I0MPN+gb9bKDt7X8SdxknYqAMh44S5L+lNqIN2NuV8nvv3g8rPp7MuRxcOpxpUIATWprO0C34a8Qmg==",
+            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^5.0.0",
                 "@octokit/graphql": "^8.1.2",
@@ -8666,6 +8732,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.1.0.tgz",
             "integrity": "sha512-3tEbUb8t8an226jKB6V/Q2XU/J53lCwCzULuBPEaF4JjSh+FlCMp7TmogE/Aij5J9DwlsZ4VAD/IRDuQ/0ZtMw==",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/crc32": "3.0.0",
                 "@smithy/types": "^1.2.0",
@@ -8878,6 +8945,7 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.0.tgz",
             "integrity": "sha512-KxAOL1nUNw2JTYrtviRRjEnykIDhxc84qMBzxvu1MUfQfHTuBlCG7PA6EdVwqpJjH7glw7FqQoFxUJSyBQgu7g==",
+            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
@@ -8938,6 +9006,7 @@
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.2.tgz",
             "integrity": "sha512-Mz+mc7okA73Lyz8zQKJNyr7lIcHLiPYp0+oiqiMNc/t7/Kf2BENs5d63pEj7oPqdjaum6g0Fc8wC78dY1TgtXw==",
+            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.1.0",
@@ -9165,6 +9234,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
             "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -9208,6 +9278,7 @@
             "resolved": "https://registry.npmjs.org/@swc-node/register/-/register-1.10.10.tgz",
             "integrity": "sha512-jYWaI2WNEKz8KZL3sExd2KVL1JMma1/J7z+9iTpv0+fRN7LGMF8VTGGuHI2bug/ztpdZU1G44FG/Kk6ElXL9CQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@swc-node/core": "^1.13.3",
                 "@swc-node/sourcemap-support": "^0.5.1",
@@ -9252,6 +9323,7 @@
             "integrity": "sha512-IUWKD6uQYGRy8w2X9EZrtYg1O3SCijlHbCXzMaHQYc1X7yjijQh4H3IVL9ssZZyVp2ZDfQZu4bD5DWxxvpyjvg==",
             "dev": true,
             "hasInstallScript": true,
+            "peer": true,
             "dependencies": {
                 "@swc/counter": "^0.1.3",
                 "@swc/types": "^0.1.17"
@@ -9455,6 +9527,7 @@
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
             "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.8.0"
             }
@@ -9464,6 +9537,7 @@
             "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.20.tgz",
             "integrity": "sha512-/rlIpxwKrhz4BIplXf6nsEHtqlhzuNN34/k3kMAXH4/lvVoA3cdq+60aqVNnyvw2uITEaCi0WV3pxBe4dQqoXQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@swc/counter": "^0.1.3"
             }
@@ -9689,6 +9763,7 @@
             "version": "22.10.2",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
             "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.20.0"
             }
@@ -9818,6 +9893,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.28.0.tgz",
             "integrity": "sha512-LPcw1yHD3ToaDEoljFEfQ9j2xShY367h7FZ1sq5NJT9I3yj4LHer1Xd1yRSOdYy9BpsrxU7R+eoDokChYM53lQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.28.0",
                 "@typescript-eslint/types": "8.28.0",
@@ -10074,6 +10150,7 @@
             "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.7.tgz",
             "integrity": "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -10097,6 +10174,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
             "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -10316,6 +10394,7 @@
             "version": "1.8.4",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
             "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
@@ -10678,6 +10757,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001688",
                 "electron-to-chromium": "^1.5.73",
@@ -11970,6 +12050,7 @@
             "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
             "dev": true,
             "hasInstallScript": true,
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -12027,6 +12108,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
             "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -12086,6 +12168,7 @@
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
             "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -13046,6 +13129,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
             "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+            "peer": true,
             "dependencies": {
                 "gaxios": "^5.0.0",
                 "json-bigint": "^1.0.0"
@@ -13142,6 +13226,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/get-tsconfig": {
+            "version": "4.13.7",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+            "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "resolve-pkg-maps": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+            }
+        },
         "node_modules/glob": {
             "version": "10.4.5",
             "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -13214,6 +13311,7 @@
             "version": "8.9.0",
             "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.9.0.tgz",
             "integrity": "sha512-f7aQCJODJFmYWN6PeNKzgvy9LI2tYmXnzpNDHEjG5sDNPgGb2FXQyTBnXeSH+PAtpKESFD+LmHw3Ox3mN7e1Fg==",
+            "peer": true,
             "dependencies": {
                 "arrify": "^2.0.0",
                 "base64-js": "^1.3.0",
@@ -13604,6 +13702,7 @@
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "devOptional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -14164,23 +14263,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/jest-circus/node_modules/babel-plugin-macros": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-            "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@babel/runtime": "^7.12.5",
-                "cosmiconfig": "^7.0.0",
-                "resolve": "^1.19.0"
-            },
-            "engines": {
-                "node": ">=10",
-                "npm": ">=6"
-            }
-        },
         "node_modules/jest-circus/node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -14203,7 +14285,6 @@
             "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "@types/parse-json": "^4.0.0",
                 "import-fresh": "^3.2.1",
@@ -17092,6 +17173,7 @@
             "integrity": "sha512-Nzi4k7tV22zwO2iBLk+pHxorLEWPJpPrVCACtz0SQ63j/LiAgfhoqruJO+VU+V+E9qdyPsvmqIL/Iaf/GRQlqA==",
             "dev": true,
             "hasInstallScript": true,
+            "peer": true,
             "dependencies": {
                 "@napi-rs/wasm-runtime": "0.2.4",
                 "@yarnpkg/lockfile": "^1.1.0",
@@ -17435,6 +17517,7 @@
             "version": "4.89.0",
             "resolved": "https://registry.npmjs.org/openai/-/openai-4.89.0.tgz",
             "integrity": "sha512-XNI0q2l8/Os6jmojxaID5EhyQjxZgzR2gWcpEjYWK5hGKwE7AcifxEY7UNwFDDHJQXqeiosQ0CJwQN+rvnwdjA==",
+            "peer": true,
             "dependencies": {
                 "@types/node": "^18.11.18",
                 "@types/node-fetch": "^2.6.4",
@@ -18386,6 +18469,16 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/resolve-pkg-maps": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
             }
         },
         "node_modules/resolve.exports": {
@@ -19458,6 +19551,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
             "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -19555,6 +19649,7 @@
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
             "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -19626,6 +19721,459 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        },
+        "node_modules/tsx": {
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+            "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "~0.27.0",
+                "get-tsconfig": "^4.7.5"
+            },
+            "bin": {
+                "tsx": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/esbuild": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.27.7",
+                "@esbuild/android-arm": "0.27.7",
+                "@esbuild/android-arm64": "0.27.7",
+                "@esbuild/android-x64": "0.27.7",
+                "@esbuild/darwin-arm64": "0.27.7",
+                "@esbuild/darwin-x64": "0.27.7",
+                "@esbuild/freebsd-arm64": "0.27.7",
+                "@esbuild/freebsd-x64": "0.27.7",
+                "@esbuild/linux-arm": "0.27.7",
+                "@esbuild/linux-arm64": "0.27.7",
+                "@esbuild/linux-ia32": "0.27.7",
+                "@esbuild/linux-loong64": "0.27.7",
+                "@esbuild/linux-mips64el": "0.27.7",
+                "@esbuild/linux-ppc64": "0.27.7",
+                "@esbuild/linux-riscv64": "0.27.7",
+                "@esbuild/linux-s390x": "0.27.7",
+                "@esbuild/linux-x64": "0.27.7",
+                "@esbuild/netbsd-arm64": "0.27.7",
+                "@esbuild/netbsd-x64": "0.27.7",
+                "@esbuild/openbsd-arm64": "0.27.7",
+                "@esbuild/openbsd-x64": "0.27.7",
+                "@esbuild/openharmony-arm64": "0.27.7",
+                "@esbuild/sunos-x64": "0.27.7",
+                "@esbuild/win32-arm64": "0.27.7",
+                "@esbuild/win32-ia32": "0.27.7",
+                "@esbuild/win32-x64": "0.27.7"
+            }
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -20234,6 +20782,7 @@
             "version": "8.18.1",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
             "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -20457,6 +21006,7 @@
             "version": "3.24.2",
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
             "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1861,7 +1861,6 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
             "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
@@ -2204,7 +2203,6 @@
             "version": "3.775.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.775.0.tgz",
             "integrity": "sha512-D8Zre5W2sXC/ANPqCWPqwYpU1cKY9DF6ckFZyDrqlcBC0gANgpY6fLrBtYo2fwJsbj+1A24iIpBINV7erdprgA==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.775.0",
                 "@aws-sdk/credential-provider-http": "3.775.0",
@@ -2277,7 +2275,6 @@
             "version": "3.775.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.775.0.tgz",
             "integrity": "sha512-THvyeStdvd0z8Dv1lJ7KrMRiZkFfUktYQUvvFT45ph14jHC5oRoPColtLHz4JjuDN5QEQ5EGrbc6USADZu1k/w==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/client-cognito-identity": "3.775.0",
                 "@aws-sdk/core": "3.775.0",
@@ -2884,7 +2881,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
             "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.26.2",
@@ -5431,7 +5427,6 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/@huggingface/inference/-/inference-2.8.1.tgz",
             "integrity": "sha512-EfsNtY9OR6JCNaUa5bZu2mrs48iqeTz0Gutwf+fU0Kypx33xFQB4DKMhp8u4Ee6qVbLbNWvTHuWwlppLQl4p4Q==",
-            "peer": true,
             "dependencies": {
                 "@huggingface/tasks": "^0.12.9"
             },
@@ -6521,7 +6516,6 @@
             "version": "0.3.15",
             "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-0.3.15.tgz",
             "integrity": "sha512-Ar2viYcZ64idgV7EtCBCb36tIkNtPAhQRxSaMTWPHGspFgMfvwRoleVri9e90sCpjpS9xhlHsIQ0LlUS/Atsrw==",
-            "peer": true,
             "dependencies": {
                 "@anthropic-ai/sdk": "^0.37.0",
                 "fast-xml-parser": "^4.4.1",
@@ -6566,7 +6560,6 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/@langchain/cohere/-/cohere-0.3.2.tgz",
             "integrity": "sha512-AWUH6DPUnn7jmuFvNMtS0VDL+fW06edQmXFxGvWvIlXFSezqECnV4opni8zCAlWgh5NGSROLtqAZc879dt5TGg==",
-            "peer": true,
             "dependencies": {
                 "cohere-ai": "^7.14.0",
                 "uuid": "^10.0.0",
@@ -6584,7 +6577,6 @@
             "version": "0.3.43",
             "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.43.tgz",
             "integrity": "sha512-DwiSUwmZqcuOn7j8SFdeOH1nvaUqG7q8qn3LhobdQYEg5PmjLgd2yLr2KzuT/YWMBfjkOR+Di5K6HEdFmouTxg==",
-            "peer": true,
             "dependencies": {
                 "@cfworker/json-schema": "^4.0.2",
                 "ansi-styles": "^5.0.0",
@@ -6648,7 +6640,6 @@
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/@langchain/google-vertexai/-/google-vertexai-0.1.8.tgz",
             "integrity": "sha512-n06ohihopz38agOm7BTASHMmFLz+XAZlzEvqtPC4Qa1fhYhzETQg2gCzEapIJ1yVk5MhrWqwKnVOQ+tIsFE88Q==",
-            "peer": true,
             "dependencies": {
                 "@langchain/google-gauth": "~0.1.8"
             },
@@ -6663,7 +6654,6 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/@langchain/mistralai/-/mistralai-0.2.0.tgz",
             "integrity": "sha512-VdfbKZopAuSXf/vlXbriGWLK3c7j5s47DoB3S31xpprY2BMSKZZiX9vE9TsgxMfAPuIDPIYcfgU7p1upvTYt8g==",
-            "peer": true,
             "dependencies": {
                 "@mistralai/mistralai": "^1.3.1",
                 "uuid": "^10.0.0",
@@ -6681,7 +6671,6 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/@langchain/ollama/-/ollama-0.1.6.tgz",
             "integrity": "sha512-hS+xHiRqKpq37eGyZQ0JoTghfNA7hWXK54XbILQ0KVm3v2MMWLKqBAep4LwMLrAr4NE7SIp+SJnQRdsjabR0jw==",
-            "peer": true,
             "dependencies": {
                 "ollama": "^0.5.12",
                 "uuid": "^10.0.0",
@@ -7977,7 +7966,6 @@
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.4.tgz",
             "integrity": "sha512-lAS9k7d6I0MPN+gb9bKDt7X8SdxknYqAMh44S5L+lNqIN2NuV8nvv3g8rPp7MuRxcOpxpUIATWprO0C34a8Qmg==",
-            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^5.0.0",
                 "@octokit/graphql": "^8.1.2",
@@ -8732,7 +8720,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.1.0.tgz",
             "integrity": "sha512-3tEbUb8t8an226jKB6V/Q2XU/J53lCwCzULuBPEaF4JjSh+FlCMp7TmogE/Aij5J9DwlsZ4VAD/IRDuQ/0ZtMw==",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/crc32": "3.0.0",
                 "@smithy/types": "^1.2.0",
@@ -8945,7 +8932,6 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.0.tgz",
             "integrity": "sha512-KxAOL1nUNw2JTYrtviRRjEnykIDhxc84qMBzxvu1MUfQfHTuBlCG7PA6EdVwqpJjH7glw7FqQoFxUJSyBQgu7g==",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
@@ -9006,7 +8992,6 @@
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.2.tgz",
             "integrity": "sha512-Mz+mc7okA73Lyz8zQKJNyr7lIcHLiPYp0+oiqiMNc/t7/Kf2BENs5d63pEj7oPqdjaum6g0Fc8wC78dY1TgtXw==",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.1.0",
@@ -9234,7 +9219,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
             "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -9278,7 +9262,6 @@
             "resolved": "https://registry.npmjs.org/@swc-node/register/-/register-1.10.10.tgz",
             "integrity": "sha512-jYWaI2WNEKz8KZL3sExd2KVL1JMma1/J7z+9iTpv0+fRN7LGMF8VTGGuHI2bug/ztpdZU1G44FG/Kk6ElXL9CQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@swc-node/core": "^1.13.3",
                 "@swc-node/sourcemap-support": "^0.5.1",
@@ -9323,7 +9306,6 @@
             "integrity": "sha512-IUWKD6uQYGRy8w2X9EZrtYg1O3SCijlHbCXzMaHQYc1X7yjijQh4H3IVL9ssZZyVp2ZDfQZu4bD5DWxxvpyjvg==",
             "dev": true,
             "hasInstallScript": true,
-            "peer": true,
             "dependencies": {
                 "@swc/counter": "^0.1.3",
                 "@swc/types": "^0.1.17"
@@ -9527,7 +9509,6 @@
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
             "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.8.0"
             }
@@ -9537,7 +9518,6 @@
             "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.20.tgz",
             "integrity": "sha512-/rlIpxwKrhz4BIplXf6nsEHtqlhzuNN34/k3kMAXH4/lvVoA3cdq+60aqVNnyvw2uITEaCi0WV3pxBe4dQqoXQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@swc/counter": "^0.1.3"
             }
@@ -9763,7 +9743,6 @@
             "version": "22.10.2",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
             "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.20.0"
             }
@@ -9893,7 +9872,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.28.0.tgz",
             "integrity": "sha512-LPcw1yHD3ToaDEoljFEfQ9j2xShY367h7FZ1sq5NJT9I3yj4LHer1Xd1yRSOdYy9BpsrxU7R+eoDokChYM53lQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.28.0",
                 "@typescript-eslint/types": "8.28.0",
@@ -10150,7 +10128,6 @@
             "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.7.tgz",
             "integrity": "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -10174,7 +10151,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
             "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -10394,7 +10370,6 @@
             "version": "1.8.4",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
             "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
@@ -10757,7 +10732,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001688",
                 "electron-to-chromium": "^1.5.73",
@@ -12050,7 +12024,6 @@
             "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
             "dev": true,
             "hasInstallScript": true,
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -12108,7 +12081,6 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
             "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -12168,7 +12140,6 @@
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
             "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -13129,7 +13100,6 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
             "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-            "peer": true,
             "dependencies": {
                 "gaxios": "^5.0.0",
                 "json-bigint": "^1.0.0"
@@ -13311,7 +13281,6 @@
             "version": "8.9.0",
             "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.9.0.tgz",
             "integrity": "sha512-f7aQCJODJFmYWN6PeNKzgvy9LI2tYmXnzpNDHEjG5sDNPgGb2FXQyTBnXeSH+PAtpKESFD+LmHw3Ox3mN7e1Fg==",
-            "peer": true,
             "dependencies": {
                 "arrify": "^2.0.0",
                 "base64-js": "^1.3.0",
@@ -13702,7 +13671,6 @@
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "devOptional": true,
-            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -14263,6 +14231,24 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/jest-circus/node_modules/babel-plugin-macros": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+            "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/runtime": "^7.12.5",
+                "cosmiconfig": "^7.0.0",
+                "resolve": "^1.19.0"
+            },
+            "engines": {
+                "node": ">=10",
+                "npm": ">=6"
+            }
+        },
         "node_modules/jest-circus/node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -14285,6 +14271,7 @@
             "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
             "dev": true,
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "@types/parse-json": "^4.0.0",
                 "import-fresh": "^3.2.1",
@@ -17173,7 +17160,6 @@
             "integrity": "sha512-Nzi4k7tV22zwO2iBLk+pHxorLEWPJpPrVCACtz0SQ63j/LiAgfhoqruJO+VU+V+E9qdyPsvmqIL/Iaf/GRQlqA==",
             "dev": true,
             "hasInstallScript": true,
-            "peer": true,
             "dependencies": {
                 "@napi-rs/wasm-runtime": "0.2.4",
                 "@yarnpkg/lockfile": "^1.1.0",
@@ -17517,7 +17503,6 @@
             "version": "4.89.0",
             "resolved": "https://registry.npmjs.org/openai/-/openai-4.89.0.tgz",
             "integrity": "sha512-XNI0q2l8/Os6jmojxaID5EhyQjxZgzR2gWcpEjYWK5hGKwE7AcifxEY7UNwFDDHJQXqeiosQ0CJwQN+rvnwdjA==",
-            "peer": true,
             "dependencies": {
                 "@types/node": "^18.11.18",
                 "@types/node-fetch": "^2.6.4",
@@ -19551,7 +19536,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
             "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -19649,7 +19633,6 @@
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
             "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -20782,7 +20765,6 @@
             "version": "8.18.1",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
             "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -21006,7 +20988,6 @@
             "version": "3.24.2",
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
             "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }


### PR DESCRIPTION
## Summary
- preserve Ollama's default `truncate` behavior unless the caller explicitly sets it
- only fall back from `/api/embed` to legacy `/api/embeddings` for explicit compatibility failures (404/405)
- keep configured `dimensions` and `truncate` on the current API path, add executable regression coverage, and wire the Ollama tests into CI
- clean up type-only exports in the shared interfaces package so the TypeScript test runner loads the workspace cleanly
- regenerate `package-lock.json` with npm 10 so the CI `npm ci` path stays in sync

## Validation
- npx npm@10 ci --ignore-scripts
- npx nx run embedjs-ollama:test
- npx nx build embedjs-ollama